### PR TITLE
Simplify Statistician Docker image

### DIFF
--- a/.github/workflows/push-index.yml
+++ b/.github/workflows/push-index.yml
@@ -8,7 +8,7 @@ on:
       - index/**
 
 env:
-  IMAGE_NAME: opendatacube/datacube-index"
+  IMAGE_NAME: opendatacube/datacube-index
 
 jobs:
   push-index:

--- a/.github/workflows/push-statistician.yml
+++ b/.github/workflows/push-statistician.yml
@@ -8,7 +8,7 @@ on:
       - statistician/**
 
 env:
-  IMAGE_NAME: opendatacube/datacube-statistician"
+  IMAGE_NAME: opendatacube/datacube-statistician
 
 jobs:
   push-stats:

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ General purpose Docker Images related to the Open Data Cube project
 
 ## Statistician
 
-See: [statistician](statistician.md).
+See: [statistician](statistician/readme.md).
 
 ## Index
 
-See: [index](index.md).
+See: [index](index/readme.md).

--- a/index/README.md
+++ b/index/README.md
@@ -1,2 +1,3 @@
-# Datacube-index-docker
-Docker file for Datacube indexing project
+# opendatacube/datacube-index
+
+Dockerfile for use in indexing into the Open Data Cube

--- a/statistician/Dockerfile
+++ b/statistician/Dockerfile
@@ -3,21 +3,23 @@ FROM opendatacube/geobase:wheels as env_builder
 ARG py_env_path=/env
 
 ENV LC_ALL=C.UTF-8
-ENV DEBIAN_FRONTEND=noninteractive
 
-# Install our requirements
+# Install our Python requirements
 RUN mkdir -p /conf
 COPY requirements.txt /conf/
 RUN env-build-tool new /conf/requirements.txt ${py_env_path} /wheels
 
 FROM opendatacube/geobase:runner
+
+ENV DEBIAN_FRONTEND=noninteractive
+
 COPY --from=env_builder /env /env
+
+ADD requirements-apt-run.txt /tmp/
 RUN apt-get update \
-    && apt-get install -y \
-    libtiff-tools \
-    python-pip \
-    && pip install --upgrade awscli \
+    && sed 's/#.*//' /tmp/requirements-apt.txt | xargs apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
+
 ENV PATH="/env/bin:${PATH}"
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/statistician/README.md
+++ b/statistician/README.md
@@ -1,2 +1,3 @@
-# odcstats-docker
-Docker file for statistician project
+# opendatacube/datacube-statistician
+
+Dockerfile for the  statistician project

--- a/statistician/docker-compose.yml
+++ b/statistician/docker-compose.yml
@@ -6,7 +6,6 @@ services:
       - POSTGRES_DB=opendatacube
       - POSTGRES_PASSWORD=opendatacubepassword
       - POSTGRES_USER=opendatacube
-
     restart: always
 
   stats:
@@ -18,8 +17,6 @@ services:
       - DB_PASSWORD=opendatacubepassword
       - DB_DATABASE=opendatacube
       - AWS_NO_SIGN_REQUEST=true
-      - STAC_API_URL=https://earth-search.aws.element84.com/v0/
-
     restart: always
     depends_on:
       - postgres

--- a/statistician/requirements-apt-run.txt
+++ b/statistician/requirements-apt-run.txt
@@ -1,0 +1,1 @@
+libtiff-tools

--- a/statistician/requirements.txt
+++ b/statistician/requirements.txt
@@ -7,10 +7,3 @@ requests
 odc-aws
 odc-aio
 odc-stats
-odc-apps-cloud
-git+https://github.com/opendatacube/datacube-index.git
-odc-index
-# Pinned for Alex to index STAC
-sat-search==0.3.0
-# test requirements, needed until testing is done separately
-pytest


### PR DESCRIPTION
There were a few issues with the Statistician Docker image.

- It was installing Python libraries that it doesn't need
- It was installing Python-Pip, when it absolutely didn't need to do that. We have a custom Python envirnoment... complex, but works. And the `aws` command line app is already installed with `aiobotocore[boto3,awscli]==1.1.1` dependency.