### PR TITLE
Make the version files invalidate the Docker build cache

### DIFF
--- a/index/Dockerfile
+++ b/index/Dockerfile
@@ -6,8 +6,9 @@ ENV LC_ALL=C.UTF-8
 
 # Install our requirements
 RUN mkdir -p /conf
-COPY requirements.txt /conf/
-RUN env-build-tool new /conf/requirements.txt ${py_env_path} /wheels
+COPY requirements.txt version.txt /conf/
+RUN cat /conf/version.txt \
+    && env-build-tool new /conf/requirements.txt ${py_env_path} /wheels
 
 FROM opendatacube/geobase:runner
 COPY --from=env_builder /env /env

--- a/statistician/Dockerfile
+++ b/statistician/Dockerfile
@@ -6,8 +6,9 @@ ENV LC_ALL=C.UTF-8
 
 # Install our Python requirements
 RUN mkdir -p /conf
-COPY requirements.txt /conf/
-RUN env-build-tool new /conf/requirements.txt ${py_env_path} /wheels
+COPY requirements.txt version.txt /conf/
+RUN cat /conf/version.txt \
+    && env-build-tool new /conf/requirements.txt ${py_env_path} /wheels
 
 FROM opendatacube/geobase:runner
 


### PR DESCRIPTION
Invalidate the cache for the index and statistician Docker images when we increment the version file.