### PR TITLE
Add non-root user to datacube-index container image

### DIFF
--- a/index/Dockerfile
+++ b/index/Dockerfile
@@ -42,6 +42,8 @@ ADD ./assets /code
 
 # Allow non-root user to read/write the python env and code dir
 RUN chown -R odc:odc /env /code
+WORKDIR /home/odc
+USER odc
 
 ## Do some symlinking
 RUN ln -s /code/bootstrap-odc.sh /usr/local/bin/bootstrap-odc.sh

--- a/index/Dockerfile
+++ b/index/Dockerfile
@@ -27,11 +27,21 @@ RUN apt-get update \
     && sed 's/#.*//' /tmp/requirements-apt-run.txt | xargs apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
+RUN groupadd --gid 1000 odc \
+  && useradd --gid 1000 --uid 1000 --create-home --shell /bin/bash -N odc \
+  && adduser odc users \
+  && install -d -o odc -g odc /env \
+  && install -d -o odc -g odc /code \
+  && true
+
 ARG py_env_path
 COPY --from=env_builder /env /env
 
 # Copy Datacube bootstrapping and other scripts
 ADD ./assets /code
+
+# Allow non-root user to read/write the python env and code dir
+RUN chown -R odc:odc /env /code
 
 ## Do some symlinking
 RUN ln -s /code/bootstrap-odc.sh /usr/local/bin/bootstrap-odc.sh

--- a/index/Dockerfile
+++ b/index/Dockerfile
@@ -42,8 +42,9 @@ ADD ./assets /code
 
 # Allow non-root user to read/write the python env and code dir
 RUN chown -R odc:odc /env /code
-WORKDIR /home/odc
-USER odc
 
 ## Do some symlinking
 RUN ln -s /code/bootstrap-odc.sh /usr/local/bin/bootstrap-odc.sh
+
+WORKDIR /home/odc
+USER odc

--- a/index/test_bootstrapping.sh
+++ b/index/test_bootstrapping.sh
@@ -4,7 +4,7 @@
 set -ex
 
 docker-compose up -d
-docker-compose run index bash -c "/code/bootstrap-odc.sh \$PRODUCT_CATALOG \$METADATA_CATALOG"
+docker-compose run index bash -c "cd \$HOME && /code/bootstrap-odc.sh \$PRODUCT_CATALOG \$METADATA_CATALOG"
 docker-compose exec -T postgres psql -U postgres -c "SELECT count(*) from agdc.metadata_type"
 docker-compose exec -T postgres psql -U postgres -c "SELECT count(*) from agdc.dataset_type"
 docker-compose down


### PR DESCRIPTION
Add a non-root user to the datacube-index docker container image, and assign permissions to allow running datacube-index image as non-root user.