### PR TITLE
Automatically update READMEs on docker hub

### DIFF
--- a/.github/workflows/index-push.yml
+++ b/.github/workflows/index-push.yml
@@ -30,3 +30,12 @@ jobs:
         username: ${{ secrets.DOCKER_USER }}
         password: ${{ secrets.DOCKER_PASS }}
         image_tag: latest,${{ env.VERSION }}
+
+    - name: Update Docker Hub Description
+      uses: peter-evans/dockerhub-description@v2
+      with:
+        username: ${{ secrets.DOCKER_USER }}
+        password: ${{ secrets.DOCKER_PASS }}
+        repository: ${{ env.IMAGE_NAME }}
+        readme-filepath: ./index/readme.md
+        short-description: Open Data Cube Indexing Image

--- a/.github/workflows/statistician-push.yml
+++ b/.github/workflows/statistician-push.yml
@@ -30,3 +30,13 @@ jobs:
         username: ${{ secrets.DOCKER_USER }}
         password: ${{ secrets.DOCKER_PASS }}
         image_tag: latest,${{ env.VERSION }}
+
+
+    - name: Update Docker Hub Description
+      uses: peter-evans/dockerhub-description@v2
+      with:
+        username: ${{ secrets.DOCKER_USER }}
+        password: ${{ secrets.DOCKER_PASS }}
+        repository: ${{ env.IMAGE_NAME }}
+        readme-filepath: ./statistician/readme.md
+        short-description: Open Data Cube Statistician Image


### PR DESCRIPTION
Currently, the pages for these images on Docker Hub look very sad and empty. This PR starts the process of fixing them by automatically syncing the README file in each of the two image directories in this repository into the related page on Docker Hub.

Next, we can start adding more documentation into each of the README files here.

![image](https://user-images.githubusercontent.com/108979/127952657-ea59d132-872b-441e-90f6-cd08324ab3a8.png)
