### PR TITLE
Add missing libxslt.so.1 to OS

### DIFF
--- a/statistician/Dockerfile
+++ b/statistician/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
          wget \
          curl \
          nano \
+         libxslt-dev \
     && rm -rf /var/lib/apt/lists/*
 
 


### PR DESCRIPTION
Looks like the OS miss the `libxslt-dev` file cause it has the error:

```
Traceback (most recent call last):
  File "/env/lib/python3.8/site-packages/odc/stats/io.py", line 250, in _ds_to_thumbnail_cog
    thumbnail_cog = self._get_thumbnail(ds, task, task.product.preview_image_ows_style, input_geobox, odc_file_path)
  File "/env/lib/python3.8/site-packages/odc/stats/io.py", line 226, in _get_thumbnail
    image = self._apply_color_ramp(ds, ows_style_dict, task)
  File "/env/lib/python3.8/site-packages/odc/stats/io.py", line 213, in _apply_color_ramp
    from datacube_ows.styles.api import StandaloneStyle
  File "/env/lib/python3.8/site-packages/datacube_ows/styles/__init__.py", line 6, in <module>
    from datacube_ows.styles.base import StyleDefBase  # noqa: F401
  File "/env/lib/python3.8/site-packages/datacube_ows/styles/base.py", line 26, in <module>
    from datacube_ows.ogc_exceptions import WMSException
  File "/env/lib/python3.8/site-packages/datacube_ows/ogc_exceptions.py", line 11, in <module>
    from ows.common.types import OWSException, Version
  File "/env/lib/python3.8/site-packages/ows/__init__.py", line 28, in <module>
    from .util import Version
  File "/env/lib/python3.8/site-packages/ows/util.py", line 34, in <module>
    from lxml import etree
ImportError: libxslt.so.1: cannot open shared object file: No such file or directory
```

Maybe we should handle it in `geobase-builder` level?