### PR TITLE
Update to GDAL 3.8.0/PyYAML 6.0.1

### DIFF
--- a/index/Dockerfile
+++ b/index/Dockerfile
@@ -5,6 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     LANG=C.UTF-8
 
 RUN apt-get update \
+    && apt-get upgrade -y \
     # Developer convenience
     && apt-get install -y --no-install-recommends \
         git \

--- a/index/Dockerfile
+++ b/index/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 RUN apt-get update \
     # Developer convenience
-    && apt-get install -y \
+    && apt-get install -y --no-install-recommends \
         git \
         fish \
         wget \

--- a/index/Dockerfile
+++ b/index/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/osgeo/gdal:ubuntu-small-3.7.2
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.8.0
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LC_ALL=C.UTF-8 \

--- a/index/constraints.txt
+++ b/index/constraints.txt
@@ -29,6 +29,7 @@ attrs==23.1.0
     # via
     #   aiohttp
     #   cattrs
+    #   datacube
     #   eodatasets3
     #   jsonschema
     #   rasterio
@@ -198,6 +199,7 @@ odc-io==0.2.1
 packaging==23.2
     # via
     #   dask
+    #   datacube
     #   distributed
     #   geoalchemy2
     #   xarray
@@ -240,7 +242,7 @@ python-rapidjson==1.12
     # via eodatasets3
 pytz==2023.3.post1
     # via pandas
-pyyaml==5.3.1
+pyyaml==6.0.1
     # via
     #   -r requirements.txt
     #   awscli

--- a/index/docker-compose.yml
+++ b/index/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.7'
 services:
   # Start docker container for PostgreSQL to mock RDS
   postgres:
+    hostname: postgres
     image: postgres:12.6-alpine
     ports:
       - "5434:5432"
@@ -10,7 +11,7 @@ services:
       POSTGRES_PASSWORD: opendatacubepassword
     restart: always
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -h postgres -U postgres"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -31,5 +32,5 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      
+
     command: tail -f /dev/null

--- a/index/requirements.txt
+++ b/index/requirements.txt
@@ -3,8 +3,7 @@ datacube[performance,s3]
 aiobotocore[awscli,boto3]
 odc-apps-dc-tools
 odc-apps-cloud
-# See https://github.com/yaml/pyyaml/issues/724
-pyyaml<=5.3.1
+pyyaml>=6.0.1
 # Libraries to compile with the local gdal
 --no-binary rasterio
 --no-binary fiona


### PR DESCRIPTION
This version of PyYAML contains a Cython < 3
build dep.

This fixes CVE-2020-14343.
