### PR TITLE
CI: fix dependabot target branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
-  target-branch: "develop"
+  target-branch: "main"


### PR DESCRIPTION
The default branch in this repository
is called main, sorry about that.