### PR TITLE
Update to aiohttp 3.9.1

### DIFF
--- a/index/constraints.txt
+++ b/index/constraints.txt
@@ -17,8 +17,10 @@ aiobotocore==2.6.0
     # via
     #   -r requirements.txt
     #   odc-cloud
-aiohttp==3.8.6
-    # via aiobotocore
+aiohttp==3.9.1
+    # via
+    #   -r requirements.txt
+    #   aiobotocore
 aioitertools==0.11.0
     # via aiobotocore
 aiosignal==1.3.1
@@ -67,9 +69,7 @@ certifi==2023.7.22
 cftime==1.6.2
     # via netcdf4
 charset-normalizer==3.3.0
-    # via
-    #   aiohttp
-    #   requests
+    # via requests
 ciso8601==2.3.0
     # via
     #   datacube

--- a/index/requirements.txt
+++ b/index/requirements.txt
@@ -1,6 +1,8 @@
 
 datacube[performance,s3]
 aiobotocore[awscli,boto3]
+# No direct dependency, avoid CVE-2023-4908{1,2} in aiohttp 3.8.6.
+aiohttp>3.8.6
 odc-apps-dc-tools
 odc-apps-cloud
 pyyaml>=6.0.1


### PR DESCRIPTION
This fixes CVE-2023-49081 and CVE-2023-49082.