### PR TITLE
dependabot: fix target directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     production-dependencies:
       dependency-type: production
 - package-ecosystem: docker
-  directory: "/"
+  directory: "/index"
   schedule:
     interval: "daily"
   target-branch: "main"


### PR DESCRIPTION
Dependabot does apparently not do a recursive
search for dockerfiles, so specify the directory
that contains the dockerfile.