### PR TITLE
Update all dependencies

### DIFF
--- a/index/constraints.txt
+++ b/index/constraints.txt
@@ -13,43 +13,43 @@ affine==2.4.0
     #   datacube
     #   eodatasets3
     #   rasterio
-aiobotocore==2.6.0
+aiobotocore==2.12.3
     # via
     #   -r requirements.txt
     #   odc-cloud
-aiohttp==3.9.3
-    # via
-    #   -r requirements.txt
-    #   aiobotocore
+aiohttp==3.9.5
+    # via aiobotocore
 aioitertools==0.11.0
     # via aiobotocore
 aiosignal==1.3.1
     # via aiohttp
 async-timeout==4.0.3
     # via aiohttp
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   aiohttp
     #   cattrs
     #   datacube
     #   eodatasets3
+    #   fiona
     #   jsonschema
     #   rasterio
-awscli==1.29.17
+    #   referencing
+awscli==1.32.69
     # via aiobotocore
 azure-core==1.30.1
     # via azure-storage-blob
 azure-storage-blob==12.19.1
     # via -r requirements.txt
-boltons==23.0.0
+boltons==24.0.0
     # via eodatasets3
-boto3==1.28.17
+boto3==1.34.69
     # via
     #   aiobotocore
     #   datacube
     #   eodatasets3
     #   odc-cloud
-botocore==1.31.17
+botocore==1.34.69
     # via
     #   aiobotocore
     #   awscli
@@ -58,25 +58,26 @@ botocore==1.31.17
     #   eodatasets3
     #   odc-cloud
     #   s3transfer
-bottleneck==1.3.7
+bottleneck==1.3.8
     # via datacube
-cachetools==5.3.1
+cachetools==5.3.3
     # via datacube
-cattrs==23.1.2
+cattrs==23.2.3
     # via eodatasets3
-certifi==2023.7.22
+certifi==2024.2.2
     # via
+    #   fiona
     #   netcdf4
     #   pyproj
     #   rasterio
     #   requests
 cffi==1.16.0
     # via cryptography
-cftime==1.6.2
+cftime==1.6.3
     # via netcdf4
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via requests
-ciso8601==2.3.0
+ciso8601==2.3.1
     # via
     #   datacube
     #   eodatasets3
@@ -88,13 +89,18 @@ click==8.1.7
     #   datacube
     #   distributed
     #   eodatasets3
+    #   fiona
     #   odc-apps-cloud
     #   odc-apps-dc-tools
     #   rasterio
 click-plugins==1.1.1
-    # via rasterio
+    # via
+    #   fiona
+    #   rasterio
 cligj==0.7.2
-    # via rasterio
+    # via
+    #   fiona
+    #   rasterio
 cloudpickle==3.0.0
     # via
     #   dask
@@ -104,50 +110,52 @@ colorama==0.4.4
     # via awscli
 cryptography==42.0.5
     # via azure-storage-blob
-dask==2023.10.0
+dask==2024.4.2
     # via
     #   datacube
     #   distributed
-datacube==1.8.16
+datacube==1.8.18
     # via
     #   -r requirements.txt
     #   eodatasets3
     #   odc-apps-dc-tools
-datadog==0.47.0
+datadog==0.49.1
     # via odc-apps-dc-tools
 defusedxml==0.7.1
     # via eodatasets3
 deprecat==2.1.1
     # via datacube
-distributed==2023.10.0
+distributed==2024.4.2
     # via datacube
 docutils==0.16
     # via awscli
-eodatasets3==0.29.7
+eodatasets3==0.30.5
     # via odc-apps-dc-tools
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via cattrs
-frozenlist==1.4.0
+fiona==1.9.6
+    # via eodatasets3
+frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2023.9.2
+fsspec==2024.3.1
     # via
     #   dask
     #   odc-apps-dc-tools
-geoalchemy2==0.14.1
+geoalchemy2==0.14.7
     # via datacube
 greenlet==3.0.3
     # via sqlalchemy
-h5py==3.10.0
+h5py==3.11.0
     # via eodatasets3
-idna==3.4
+idna==3.7
     # via
     #   requests
     #   yarl
-importlib-metadata==6.8.0
+importlib-metadata==7.1.0
     # via dask
-importlib-resources==6.1.0
+importlib-resources==6.4.0
     # via odc-apps-dc-tools
 isodate==0.6.1
     # via azure-storage-blob
@@ -157,28 +165,30 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.17.3
+jsonschema==4.21.1
     # via
     #   datacube
     #   eodatasets3
     #   pystac
-lark==1.1.7
+jsonschema-specifications==2023.12.1
+    # via jsonschema
+lark==1.1.9
     # via datacube
 locket==1.0.0
     # via
     #   distributed
     #   partd
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via jinja2
-msgpack==1.0.7
+msgpack==1.0.8
     # via distributed
-multidict==6.0.4
+multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-netcdf4==1.6.4
+netcdf4==1.6.5
     # via datacube
-numpy==1.26.1
+numpy==1.26.4
     # via
     #   bottleneck
     #   cftime
@@ -193,65 +203,63 @@ numpy==1.26.1
     #   shapely
     #   snuggs
     #   xarray
-odc-apps-cloud==0.2.2
+odc-apps-cloud==0.2.3
     # via -r requirements.txt
 odc-apps-dc-tools==0.2.16
     # via -r requirements.txt
-odc-cloud==0.2.3
+odc-cloud==0.2.5
     # via
     #   odc-apps-cloud
     #   odc-apps-dc-tools
-odc-io==0.2.1
+odc-io==0.2.2
     # via
     #   odc-apps-cloud
     #   odc-apps-dc-tools
-packaging==23.2
+packaging==24.0
     # via
     #   dask
     #   datacube
     #   distributed
     #   geoalchemy2
     #   xarray
-pandas==2.1.1
+pandas==2.2.2
     # via
     #   datacube
     #   xarray
 partd==1.4.1
     # via dask
-psutil==5.9.6
+psutil==5.9.8
     # via distributed
 psycopg2==2.9.9
     # via datacube
-pyasn1==0.5.0
+pyasn1==0.6.0
     # via rsa
 pycparser==2.22
     # via cffi
-pyparsing==3.1.1
+pyparsing==3.1.2
     # via snuggs
 pyproj==3.6.1
     # via
     #   datacube
     #   eodatasets3
-pyrsistent==0.19.3
-    # via jsonschema
-pystac==1.8.3
+pystac==1.10.0
     # via
     #   eodatasets3
     #   odc-apps-dc-tools
     #   pystac-client
     #   rio-stac
-pystac-client==0.7.5
+pystac-client==0.7.7
     # via odc-apps-dc-tools
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   datacube
     #   pandas
     #   pystac
     #   pystac-client
-python-rapidjson==1.12
+python-rapidjson==1.16
     # via eodatasets3
-pytz==2023.3.post1
+pytz==2024.1
     # via pandas
 pyyaml==6.0.1
     # via
@@ -261,91 +269,99 @@ pyyaml==6.0.1
     #   datacube
     #   distributed
     #   odc-apps-dc-tools
-rasterio==1.3.8.post2
+rasterio==1.3.10
     # via
     #   datacube
     #   eodatasets3
     #   rio-stac
+referencing==0.34.0
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   azure-core
     #   datadog
     #   pystac-client
     #   urlpath
-rio-stac==0.8.1
+rio-stac==0.9.0
     # via odc-apps-dc-tools
+rpds-py==0.18.0
+    # via
+    #   jsonschema
+    #   referencing
 rsa==4.7.2
     # via awscli
-ruamel-yaml==0.17.35
+ruamel-yaml==0.18.6
     # via
     #   datacube
     #   eodatasets3
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-s3transfer==0.6.2
+s3transfer==0.10.1
     # via
     #   awscli
     #   boto3
-scipy==1.11.3
+scipy==1.13.0
     # via eodatasets3
-shapely==2.0.2
+shapely==2.0.4
     # via
     #   datacube
     #   eodatasets3
 six==1.16.0
     # via
     #   azure-core
+    #   fiona
     #   isodate
     #   python-dateutil
 snuggs==1.4.7
     # via rasterio
 sortedcontainers==2.4.0
     # via distributed
-sqlalchemy==1.4.49
+sqlalchemy==1.4.52
     # via
     #   datacube
     #   geoalchemy2
-structlog==23.2.0
+structlog==24.1.0
     # via eodatasets3
-tblib==2.0.0
+tblib==3.0.0
     # via distributed
-toolz==0.12.0
+toolz==0.12.1
     # via
     #   dask
     #   datacube
     #   distributed
     #   odc-apps-dc-tools
     #   partd
-tornado==6.3.3
+tornado==6.4
     # via distributed
 typing-extensions==4.11.0
     # via
     #   azure-core
     #   azure-storage-blob
     #   cattrs
-tzdata==2023.3
+tzdata==2024.1
     # via pandas
-urllib3==1.26.18
+urllib3==2.2.1
     # via
-    #   -r requirements.txt
     #   botocore
     #   distributed
     #   requests
 urlpath==1.2.0
     # via odc-apps-dc-tools
-wrapt==1.15.0
+wrapt==1.16.0
     # via
     #   aiobotocore
     #   deprecat
-xarray==2023.9.0
+xarray==2024.3.0
     # via
     #   datacube
     #   eodatasets3
-yarl==1.9.2
+yarl==1.9.4
     # via aiohttp
 zict==3.0.0
     # via distributed
-zipp==3.17.0
+zipp==3.18.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/index/requirements.txt
+++ b/index/requirements.txt
@@ -3,13 +3,9 @@ datacube[performance,s3]
 aiobotocore[awscli,boto3]
 #Azure indexing, just in case
 azure-storage-blob
-# No direct dependency, avoid CVE-2024-23334/CVE-2024-23829 in aiohttp 3.9.1.
-aiohttp>3.9.1
 odc-apps-dc-tools
 odc-apps-cloud
 pyyaml>=6.0.1
-# No direct dependency, avoid CVE-2023-45803 in urllib3 1.26.17.
-urllib3>1.26.17
 # Libraries to compile with the local gdal
 --no-binary rasterio
 --no-binary fiona


### PR DESCRIPTION
This brings in the latest version
of all dependencies.

Updating everything to the latest version
eliminates the need to specify versions
for the dependencies of our dependencies
in requirements.txt.