### PR TITLE
index/docker-compose: remove obsolete field

### DIFF
--- a/index/docker-compose.yml
+++ b/index/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   # Start docker container for PostgreSQL to mock RDS
   postgres:


### PR DESCRIPTION
This eliminates:

time="2024-07-24T09:16:14Z" level=warning msg="/home/runner/work/datacube-docker/datacube-docker/index/docker-compose.yml: `version` is obsolete"

from the CI test logs.