### PR TITLE
index/readme: rm container after completion

### DIFF
--- a/index/readme.md
+++ b/index/readme.md
@@ -18,7 +18,7 @@ pip-compile --upgrade --output-file constraints.txt --strip-extras requirements.
 To minimise version changes, update using the existing image (run from index folder):
 
 ```
-docker run -v $(pwd):/datacube-index/ -w /datacube-index -it opendatacube/datacube-index bash -c "python3 -m pip install pip-tools && pip-compile --upgrade --output-file constraints.txt --strip-extras requirements.txt"
+docker run --rm -v $(pwd):/datacube-index/ -w /datacube-index -it opendatacube/datacube-index bash -c "python3 -m pip install pip-tools && pip-compile --upgrade --output-file constraints.txt --strip-extras requirements.txt"
 ```
 
 


### PR DESCRIPTION
There is no point in keeping the container
around after its completion, so add --rm
to the command.