### PR TITLE
dependabot: update uv.lock

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,8 @@ updates:
   schedule:
     interval: "daily"
   target-branch: "main"
+- package-ecosystem: "uv"
+  directory: "/index"
+  schedule:
+    interval: "daily"
+  target-branch: "main"


### PR DESCRIPTION
Get Dependabot to make pull requests
so we can just merge updates instead
of updating the lock file manually.