### PR TITLE
Add a step that pushes to GHCR

### DIFF
--- a/.github/workflows/index-image.yml
+++ b/.github/workflows/index-image.yml
@@ -39,6 +39,7 @@ jobs:
         make test-indexing
 
   push:
+    permissions: write-all
     if: github.ref == 'refs/heads/main'
     needs: test
     runs-on: ubuntu-latest
@@ -80,3 +81,15 @@ jobs:
         repository: ${{ env.IMAGE_NAME }}
         readme-filepath: ./index/readme.md
         short-description: Open Data Cube Indexing Image
+
+    # Push to the GitHub Container Registry too
+    - name: Push to GHCR
+      uses: whoan/docker-build-with-cache-action@v8
+      with:
+        context: index
+        registry: docker.pkg.github.com
+        image_name: ghcr.io/${{ env.IMAGE_NAME }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        image_tag: latest,${{ env.VERSION }}
+  


### PR DESCRIPTION
Adding a push to GitHub Container Repository.

Usually I do this a little different.

One question for people is should we remove the Docker Hub pushing now? Not sure if we can deprecate it somehow...