### PR TITLE
CI: disable pull progress meter

### DIFF
--- a/index/Makefile
+++ b/index/Makefile
@@ -12,7 +12,7 @@ make build:
 	docker compose build
 
 up:
-	docker compose up
+	docker compose up --quiet-pull
 
 down:
 	docker compose down

--- a/index/test_bootstrapping.sh
+++ b/index/test_bootstrapping.sh
@@ -3,7 +3,7 @@
 # Echo lines and fail fast
 set -ex
 
-docker compose up -d
+docker compose up -d --quiet-pull
 
 # This workflow is soooo flaky. External data dependencies have broken it!
 docker compose run --user ubuntu index bash -c "cd \$HOME && /code/bootstrap-odc.sh \$PRODUCT_CATALOG \$METADATA_CATALOG" || \

--- a/index/test_indexing.sh
+++ b/index/test_indexing.sh
@@ -3,7 +3,7 @@
 # Echo lines and fail fast
 set -ex
 
-docker compose up -d
+docker compose up -d --quiet-pull
 docker compose exec --user ubuntu -T index datacube system init
 docker compose exec --user ubuntu -T index datacube system check
 echo "Checking InSAR indexing"


### PR DESCRIPTION
The CI logs are easier to read
without the graphical progress
meter.