### PR TITLE
Dockerfile: upgrade to uv 0.8.6

### DIFF
--- a/index/Dockerfile
+++ b/index/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM ghcr.io/osgeo/gdal:ubuntu-small-3.11.0 AS builder
 
-ARG UV=https://github.com/astral-sh/uv/releases/download/0.7.2/uv-x86_64-unknown-linux-gnu.tar.gz
+ARG UV=https://github.com/astral-sh/uv/releases/download/0.8.6/uv-x86_64-unknown-linux-gnu.tar.gz
 
 ENV LC_ALL=C.UTF-8 \
     LANG=C.UTF-8 \
@@ -36,7 +36,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 WORKDIR /build
 
-ADD --checksum=sha256:cfaab1b5166a6439ff66f020333d3a12bbdf622deee3b510718283e8f06c9de7 --chown=root:root --chmod=644 --link $UV uv.tar.gz
+ADD --checksum=sha256:5429c9b96cab65198c2e5bfe83e933329aa16303a0369d5beedc71785a4a2f36 --chown=root:root --chmod=644 --link $UV uv.tar.gz
 
 
 RUN tar xf uv.tar.gz -C /usr/local/bin --strip-components=1 --no-same-owner


### PR DESCRIPTION
This fixes CVE-2025-54368.