### PR TITLE
CI: stop persisting credentials

### DIFF
--- a/.github/workflows/index-image.yml
+++ b/.github/workflows/index-image.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Run Dockerized Bootstrapping from Git
       timeout-minutes: 20
@@ -49,6 +51,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Verify Changed files
       uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5


### PR DESCRIPTION
This makes it harder for attackers
to get access to the credentials.